### PR TITLE
Fix the PlantUML sequence diagram activation bug existing in default Puma engine

### DIFF
--- a/tests/test_sequence_diagram.py
+++ b/tests/test_sequence_diagram.py
@@ -496,6 +496,12 @@ p2-->>p1: Return to first
 deactivate p2
 deactivate p1
 end
+activate p3
+p3->>p1: 
+activate p1
+p1-->>p3: Short reverse direct connection
+deactivate p1
+deactivate p3
 """,
             ),
             (
@@ -519,6 +525,13 @@ p2-->p1: Return to first
 deactivate p2
 deactivate p1
 end
+p3 -[hidden]-> p3
+activate p3 
+p3->p1: 
+activate p1 
+p1-->p3: Short reverse direct connection
+deactivate p1
+deactivate p3
 @enduml
 """,
             ),
@@ -540,6 +553,8 @@ p3.2 -> p2.1: Return to second {style.stroke-dash: 3}
 }
 p2.1 -> p1.0: Return to first {style.stroke-dash: 3}
 }
+p3.3 -> p1.4: ''
+p1.4 -> p3.3: Short reverse direct connection {style.stroke-dash: 3}
 }
 """,
             ),
@@ -563,6 +578,12 @@ p2-->p1: Return to first
 deactivate p2
 deactivate p1
 end
+activate p3
+p3->p1: 
+activate p1
+p1-->p3: Short reverse direct connection
+deactivate p1
+deactivate p3
 """,
             ),
         ),
@@ -583,6 +604,8 @@ end
             ):
                 second.go_to(third, "Go to third").return_to(second, "Return to second")
             second.return_to(first, "Return to first")
+
+        third.go_to(first).return_to(third, "Short reverse direct connection")
         assert str(sd) == output
 
     @pytest.mark.parametrize(
@@ -1105,7 +1128,6 @@ activate p5
 
         sd.group_participants("A first\ngroup", grouped_2, grouped_3)
         sd.group_participants("A second\ngroup", grouped_5)
-        print(str(sd))
         assert str(sd) == output
 
     @pytest.mark.parametrize(
@@ -1237,7 +1259,6 @@ activate p5
         ).go_to(p5, "Message!")
 
         sd.group_participants("A third\ngroup", p4, p5)
-        print(sd)
         assert str(sd) == output
 
     @pytest.mark.parametrize(
@@ -1420,7 +1441,6 @@ deactivate p1
         entity.return_to(control, "Return").return_to(boundary, "Return").return_to(
             actor, "Return"
         )
-        print(sd)
         assert str(sd) == output
 
     def test_invalid_color_string(self):

--- a/umlcharter/__init__.py
+++ b/umlcharter/__init__.py
@@ -5,7 +5,7 @@ from .generators.plantuml.plantuml import PlantUML
 from .generators.d2.d2 import D2
 from .generators.sequencediagramorg.sequencediagramorg import SequenceDiagramOrg
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 __all__ = (
     # charts

--- a/umlcharter/generators/d2/sequence_diagram.py
+++ b/umlcharter/generators/d2/sequence_diagram.py
@@ -30,8 +30,8 @@ class D2SequenceDiagram:
         sequence: typing.List[Step] = sequence_diagram._SequenceDiagram__sequence  # noqa
 
         last_targeted_participant: SequenceDiagramParticipant | None = None
-        aliases = {}
-        aliases_counter = 1
+        aliases: typing.Dict[SequenceDiagramParticipant, str] = {}
+        aliases_counter: int = 1
 
         participant_types_map = {
             "default": "",

--- a/umlcharter/generators/mermaid/sequence_diagram.py
+++ b/umlcharter/generators/mermaid/sequence_diagram.py
@@ -34,10 +34,10 @@ class MermaidSequenceDiagram:
         ] = sequence_diagram._SequenceDiagram__participants  # noqa
         sequence: typing.List[Step] = sequence_diagram._SequenceDiagram__sequence  # noqa
 
-        first_case = False
+        first_case: bool = False
         last_targeted_participant: SequenceDiagramParticipant | None = None
-        aliases = {}
-        aliases_counter = 1
+        aliases: typing.Dict[SequenceDiagramParticipant, str] = {}
+        aliases_counter: int = 1
 
         participant_types_map = {
             "default": "participant",

--- a/umlcharter/generators/sequencediagramorg/sequence_diagram.py
+++ b/umlcharter/generators/sequencediagramorg/sequence_diagram.py
@@ -34,10 +34,10 @@ class SequenceDiagramOrgSequenceDiagram:
         ] = sequence_diagram._SequenceDiagram__participants  # noqa
         sequence: typing.List[Step] = sequence_diagram._SequenceDiagram__sequence  # noqa
 
-        first_case = False
+        first_case: bool = False
         last_targeted_participant: SequenceDiagramParticipant | None = None
-        aliases = {}
-        aliases_counter = 1
+        aliases: typing.Dict[SequenceDiagramParticipant, str] = {}
+        aliases_counter: int = 1
 
         participant_types_map = {
             "default": "participant",


### PR DESCRIPTION
Fix the PlantUML sequence diagram activation bug existing for years in the default Puma architecture by using the invisible message to "restart" (?) the activation